### PR TITLE
Add Plash header

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -71,6 +71,7 @@
     "        raise FileNotFoundError(\"Plash config not found. Please run plash_login and try again.\")\n",
     "    cookies = Path(cookie_file).read_json()\n",
     "    client.cookies.update(cookies)\n",
+    "    client.headers.update({'X-PLASH': 'true'})\n",
     "    return client"
    ]
   },

--- a/plash_cli/core.py
+++ b/plash_cli/core.py
@@ -27,6 +27,7 @@ def get_client(cookie_file):
         raise FileNotFoundError("Plash config not found. Please run plash_login and try again.")
     cookies = Path(cookie_file).read_json()
     client.cookies.update(cookies)
+    client.headers.update({'X-PLASH': True})
     return client
 
 # %% ../nbs/00_core.ipynb 6

--- a/plash_cli/core.py
+++ b/plash_cli/core.py
@@ -27,7 +27,7 @@ def get_client(cookie_file):
         raise FileNotFoundError("Plash config not found. Please run plash_login and try again.")
     cookies = Path(cookie_file).read_json()
     client.cookies.update(cookies)
-    client.headers.update({'X-PLASH': True})
+    client.headers.update({'X-PLASH': 'true'})
     return client
 
 # %% ../nbs/00_core.ipynb 6


### PR DESCRIPTION
Adds a header so for requests to Plash we can have client-based responses. For example, a web browser request will be different than a CLI request.