### PR TITLE
set httpx minver as raise for status does not return resp for httpx<0.25

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -26,7 +26,7 @@ keywords = nbdev jupyter notebook python
 language = English
 status = 3
 user = AnswerDotAI
-requirements = fastcore httpx
+requirements = fastcore httpx>=0.28.1
 console_scripts = plash_deploy=plash_cli.core:deploy
 	plash_login=plash_cli.core:login
 	plash_view=plash_cli.core:view


### PR DESCRIPTION
This PR addresses the edge case where an old version of httpx breaks the plash_login flow as `raise_for_status` does not return the original request.