### PR TITLE
End log when build has completed

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -495,6 +495,7 @@
     "                if r.status_code == 200:\n",
     "                    print(r.text[len(text):], end='') # Only print updates\n",
     "                    text = r.text\n",
+    "                    if mode == 'build' and 'Build End Time:' in r.text: break\n",
     "                    sleep(1)\n",
     "                else:\n",
     "                    print(f\"Error: {r.status_code}\")\n",

--- a/plash_cli/core.py
+++ b/plash_cli/core.py
@@ -210,6 +210,7 @@ def logs(
                 if r.status_code == 200:
                     print(r.text[len(text):], end='') # Only print updates
                     text = r.text
+                    if mode == 'build' and 'Build End Time:' in r.text: break
                     sleep(1)
                 else:
                     print(f"Error: {r.status_code}")


### PR DESCRIPTION
This PR triggers the end of the `logs` function when in `build` mode when the `build` finishes. 