### PR TITLE
fix deploy cmd docstring to clarify exclusions of dot files

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -338,7 +338,7 @@
     "def deploy(\n",
     "    path:Path=Path('.'), # Path to project\n",
     "    app_id:str=None):    # Overrides the .plash file in project root if provided\n",
-    "    'Ship your app to production'\n",
+    "    \"Deploy app to production (ignores paths starting with '.')\"\n",
     "    print('Initializing deployment...')\n",
     "    if app_id == '': print('Error: App ID cannot be an empty string'); return\n",
     "    if not path.is_dir(): print(\"Error: Path should point to the project directory\"); return\n",

--- a/nbs/reference/00_cli.ipynb
+++ b/nbs/reference/00_cli.ipynb
@@ -39,12 +39,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_login [-h]\n",
-      "\n",
-      "Authenticate CLI with server and save config\n",
-      "\n",
-      "options:\n",
-      "  -h, --help  show this help message and exit\n",
+      "usage: plash_login [-h]\r\n",
+      "\r\n",
+      "Authenticate CLI with server and save config\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help  show this help message and exit\r\n",
       "\n"
      ]
     }
@@ -72,14 +72,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_deploy [-h] [--path PATH] [--app_id APP_ID]\n",
-      "\n",
-      "Ship your app to production\n",
-      "\n",
-      "options:\n",
-      "  -h, --help       show this help message and exit\n",
-      "  --path PATH      Path to project (default: .)\n",
-      "  --app_id APP_ID  Overrides the .plash file in project root if provided\n",
+      "usage: plash_deploy [-h] [--path PATH] [--app_id APP_ID]\r\n",
+      "\r\n",
+      "Deploy app to production (ignores paths starting with '.')\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help       show this help message and exit\r\n",
+      "  --path PATH      Path to project (default: .)\r\n",
+      "  --app_id APP_ID  Overrides the .plash file in project root if provided\r\n",
       "\n"
      ]
     }
@@ -107,14 +107,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_view [-h] [--path PATH] [--app_id APP_ID]\n",
-      "\n",
-      "Open your app in the browser\n",
-      "\n",
-      "options:\n",
-      "  -h, --help       show this help message and exit\n",
-      "  --path PATH      Path to project directory (default: .)\n",
-      "  --app_id APP_ID  Overrides the .plash file in project root if provided\n",
+      "usage: plash_view [-h] [--path PATH] [--app_id APP_ID]\r\n",
+      "\r\n",
+      "Open your app in the browser\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help       show this help message and exit\r\n",
+      "  --path PATH      Path to project directory (default: .)\r\n",
+      "  --app_id APP_ID  Overrides the .plash file in project root if provided\r\n",
       "\n"
      ]
     }
@@ -142,14 +142,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_start [-h] [--path PATH] [--app_id APP_ID]\n",
-      "\n",
-      "Access the '/start' endpoint for your app\n",
-      "\n",
-      "options:\n",
-      "  -h, --help       show this help message and exit\n",
-      "  --path PATH      Path to project (default: .)\n",
-      "  --app_id APP_ID  Overrides the .plash file in project root if provided\n",
+      "usage: plash_start [-h] [--path PATH] [--app_id APP_ID]\r\n",
+      "\r\n",
+      "Access the '/start' endpoint for your app\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help       show this help message and exit\r\n",
+      "  --path PATH      Path to project (default: .)\r\n",
+      "  --app_id APP_ID  Overrides the .plash file in project root if provided\r\n",
       "\n"
      ]
     }
@@ -177,14 +177,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_stop [-h] [--path PATH] [--app_id APP_ID]\n",
-      "\n",
-      "Access the '/stop' endpoint for your app\n",
-      "\n",
-      "options:\n",
-      "  -h, --help       show this help message and exit\n",
-      "  --path PATH      Path to project (default: .)\n",
-      "  --app_id APP_ID  Overrides the .plash file in project root if provided\n",
+      "usage: plash_stop [-h] [--path PATH] [--app_id APP_ID]\r\n",
+      "\r\n",
+      "Access the '/stop' endpoint for your app\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help       show this help message and exit\r\n",
+      "  --path PATH      Path to project (default: .)\r\n",
+      "  --app_id APP_ID  Overrides the .plash file in project root if provided\r\n",
       "\n"
      ]
     }
@@ -212,17 +212,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_logs [-h] [--path PATH] [--app_id APP_ID] [--mode {build,app}]\n",
-      "                  [--tail]\n",
-      "\n",
-      "Prints the logs for your deployed app\n",
-      "\n",
-      "options:\n",
-      "  -h, --help          show this help message and exit\n",
-      "  --path PATH         Path to project (default: .)\n",
-      "  --app_id APP_ID     Overrides the .plash file in project root if provided\n",
-      "  --mode {build,app}  Choose between build or app logs (default: build)\n",
-      "  --tail              Tail the logs (default: False)\n",
+      "usage: plash_logs [-h] [--path PATH] [--app_id APP_ID] [--mode {build,app}]\r\n",
+      "                  [--tail]\r\n",
+      "\r\n",
+      "Prints the logs for your deployed app\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help          show this help message and exit\r\n",
+      "  --path PATH         Path to project (default: .)\r\n",
+      "  --app_id APP_ID     Overrides the .plash file in project root if provided\r\n",
+      "  --mode {build,app}  Choose between build or app logs (default: build)\r\n",
+      "  --tail              Tail the logs (default: False)\r\n",
       "\n"
      ]
     }
@@ -250,16 +250,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_download [-h] [--path PATH] [--app_id APP_ID]\n",
-      "                      [--save_path SAVE_PATH]\n",
-      "\n",
-      "Download your deployed app\n",
-      "\n",
-      "options:\n",
-      "  -h, --help             show this help message and exit\n",
-      "  --path PATH            Path to project (default: .)\n",
-      "  --app_id APP_ID        Overrides the .plash file in project root if provided\n",
-      "  --save_path SAVE_PATH  Save path (optional) (default: download)\n",
+      "usage: plash_download [-h] [--path PATH] [--app_id APP_ID]\r\n",
+      "                      [--save_path SAVE_PATH]\r\n",
+      "\r\n",
+      "Download your deployed app\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help             show this help message and exit\r\n",
+      "  --path PATH            Path to project (default: .)\r\n",
+      "  --app_id APP_ID        Overrides the .plash file in project root if provided\r\n",
+      "  --save_path SAVE_PATH  Save path (optional) (default: download)\r\n",
       "\n"
      ]
     }
@@ -287,15 +287,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: plash_delete [-h] [--path PATH] [--app_id APP_ID] [--force]\n",
-      "\n",
-      "Delete your deployed app\n",
-      "\n",
-      "options:\n",
-      "  -h, --help       show this help message and exit\n",
-      "  --path PATH      Path to project (default: .)\n",
-      "  --app_id APP_ID  Overrides the .plash file in project root if provided\n",
-      "  --force          Skip confirmation prompt (default: False)\n",
+      "usage: plash_delete [-h] [--path PATH] [--app_id APP_ID] [--force]\r\n",
+      "\r\n",
+      "Delete your deployed app\r\n",
+      "\r\n",
+      "options:\r\n",
+      "  -h, --help       show this help message and exit\r\n",
+      "  --path PATH      Path to project (default: .)\r\n",
+      "  --app_id APP_ID  Overrides the .plash file in project root if provided\r\n",
+      "  --force          Skip confirmation prompt (default: False)\r\n",
       "\n"
      ]
     }

--- a/plash_cli/core.py
+++ b/plash_cli/core.py
@@ -125,7 +125,7 @@ def create_tar_archive(path:Path) -> tuple[io.BytesIO, int]:
 def deploy(
     path:Path=Path('.'), # Path to project
     app_id:str=None):    # Overrides the .plash file in project root if provided
-    'Ship your app to production'
+    "Deploy app to production (ignores paths starting with '.')"
     print('Initializing deployment...')
     if app_id == '': print('Error: App ID cannot be an empty string'); return
     if not path.is_dir(): print("Error: Path should point to the project directory"); return


### PR DESCRIPTION
An early adopter found this behavior surprising so lets document it more clearly.