### PR TITLE
Add FastHTML tutorials to 'Where to go next' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,14 @@ When you visit that page you should see “Hello, World!”
 
 Learn more about what Plash has to offer in the rest of the docs at:
 <https://docs.pla.sh>
+
+For learning more about creating web apps with FastHTML, we recommend
+looking at the official docs at: <https://fastht.ml/docs/>.
+
+Particularly, we recommend the following:
+
+1.  [OAuth](https://fastht.ml/docs/explains/oauth.html) - Setup
+    authentication for your Plash App with Google Sign-In or other OAuth
+    Providers.
+2.  [Stripe](https://fastht.ml/docs/explains/stripe.html) - Accept
+    payments for your products hosted on Plash with Stripe.

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -331,7 +331,14 @@
    "source": [
     "## Where to go from here\n",
     "\n",
-    "Learn more about what Plash has to offer in the rest of the docs at: [https://docs.pla.sh](https://docs.pla.sh)"
+    "Learn more about what Plash has to offer in the rest of the docs at: [https://docs.pla.sh](https://docs.pla.sh)\n",
+    "\n",
+    "For learning more about creating web apps with FastHTML, we recommend looking at the official docs at: [https://fastht.ml/docs/](https://fastht.ml/docs/).\n",
+    "\n",
+    "Particularly, we recommend the following:\n",
+    "\n",
+    "1. [OAuth](https://fastht.ml/docs/explains/oauth.html) - Setup authentication for your Plash App with Google Sign-In or other OAuth Providers.\n",
+    "2. [Stripe](https://fastht.ml/docs/explains/stripe.html) - Accept payments for your products hosted on Plash with Stripe."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Added FastHTML tutorial links to the 'Where to go next' section in the documentation to help users learn how to build web applications with FastHTML after deploying with Plash.