### PR TITLE
use asyncstdlib cache for docs site.

### DIFF
--- a/docs_site/main.py
+++ b/docs_site/main.py
@@ -1,12 +1,12 @@
 from fasthtml.common import *
-from fastcore.xtras import flexicache, mtime_policy
+from asyncstdlib.functools import cache
 
 app = FastHTML()
-cached_file_response = flexicache(mtime_policy("_docs"))(FileResponse)
 
 @app.get("/{path:path}")
+@cache
 async def static(path:str): 
-    if "." in path: return cached_file_response(f'_docs/{path}')
-    return cached_file_response(f'_docs/{path}/index.html')
+    if "." not in path: path += "/index.html"
+    return FileResponse(f'_docs/{path}')
 
 serve()

--- a/docs_site/requirements.txt
+++ b/docs_site/requirements.txt
@@ -1,1 +1,2 @@
 python-fasthtml
+asyncstdlib

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -6,3 +6,4 @@ rm -rf docs_site/_docs
 nbdev_docs
 cp -r _docs docs_site/
 plash_deploy --path docs_site ${1:+--name "$1"}
+plash_logs --tail ${1:+--name "$1"}


### PR DESCRIPTION
Old approach using mtime cache didnt work great, it raised this error after some time: `RuntimeError: Response content longer than Content-Length`. Probably the cache didnt get properly invalidated on redeploys. Maybe because mtime doesnt take file modifications inside the dir into account.

This version using asyncstdlib is better: the code is more concise, and I manually tested that the cache gets cleared when files change.