### PR TITLE
Fix quoting issue

### DIFF
--- a/plash_cli/core.py
+++ b/plash_cli/core.py
@@ -162,7 +162,7 @@ def deploy(
                        data={'name': name, 'force_data': force_data})
     if resp.status_code == 200:
         print('✅ Upload complete! Your app is currently being built.')
-        print(f'It will be live at {name if '.' in name else endpoint(sub=name)}')
+        print(f"It will be live at {name if '.' in name else endpoint(sub=name)}")
     else: print(f'Failure: {resp.status_code}\n{resp.text}')
 
 # %% ../nbs/00_core.ipynb 28


### PR DESCRIPTION
got this on first installation:

```bash
thomas@T4CW9XJ4DW evalui % plash_login
Traceback (most recent call last):
  File "/Users/thomas/Repos/playground/evalui/.venv/bin/plash_login", line 4, in <module>
    from plash_cli.core import login
  File "/Users/thomas/Repos/playground/evalui/.venv/lib/python3.10/site-packages/plash_cli/core.py", line 165
    print(f'It will be live at {name if '.' in name else endpoint(sub=name)}')
                                         ^
SyntaxError: f-string: expecting '}'
```

this should fix it